### PR TITLE
Avoid trunc error in smarsa_BirthSpacings in bigcrushJulia

### DIFF
--- a/src/RNGTest.jl
+++ b/src/RNGTest.jl
@@ -964,7 +964,7 @@ module RNGTest
                       g->smarsa_CollisionOver(g, 30, 2*10^7, 27, 8, 14),
                       g->smarsa_CollisionOver(g, 30, 2*10^7, 0, 4, 21),
                       g->smarsa_CollisionOver(g, 30, 2*10^7, 28, 4, 21),
-                      g->smarsa_BirthdaySpacings(g, 100, 10^7, 0, 2^31, 2, 1),
+                      g->smarsa_BirthdaySpacings(g, 250, 4*10^6, 0, 2^30, 2, 1),
                       g->smarsa_BirthdaySpacings(g, 20, 2*10^7, 0, 2^21, 3, 1),
                       g->smarsa_BirthdaySpacings(g, 20, 3*10^7, 14, 2^16, 4, 1),
                       g->smarsa_BirthdaySpacings(g, 20, 2*10^7, 0, 2^9, 7, 1),


### PR DESCRIPTION
Issue #28

Fix for `bigcrushJulia` battery test.
Use alternative parameters for `smarsa_BirthdaySpacings` to avoid error when converting `2^31` to `Int32`.

Copied alternative parameters from TestU01 c code (`testu01/bbattery.c`)
```
  {
      sres_Poisson *res;
      res = sres_CreatePoisson ();
#ifdef USE_LONGLONG
      ++j2;
      for (i = 0; i < Rep[j2]; ++i) {
         long d;
#if LONG_MAX <= 2147483647L
         d = 1073741824L;
         smarsa_BirthdaySpacings (gen, res, 250, 4 * MILLION, 0, d, 2, 1);
#else
         d = 2147483648L;
         smarsa_BirthdaySpacings (gen, res, 100, 10 * MILLION, 0, d, 2, 1);
#endif
         bbattery_pVal[++j] = res->pVal2;
         TestNumber[j] = j2;
         strcpy (bbattery_TestNames[j], "BirthdaySpacings, t = 2");
      }
```